### PR TITLE
ENT-14 | Add CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/about-codeowners/
+* @acquia/enterprise-apps @acquia/push-acquia-ra-composer
+


### PR DESCRIPTION
## About CODEOWNERS

Use a CODEOWNERS file to define individuals or teams that are responsible for code in a repository.

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. When someone with admin permissions has enabled required reviews, they can optionally require approval from a code owner.

To use a CODEOWNERS file, create a new file called CODEOWNERS in the root or .github/ directory of the repository.

See: https://help.github.com/articles/about-codeowners/