### PR TITLE
RADX-538 | Composerize process failed where addPatch method call of composerize-drupal

### DIFF
--- a/composer-templates/template.composer.json
+++ b/composer-templates/template.composer.json
@@ -30,11 +30,7 @@
   "prefer-stable": true,
   "extra": {
     "enable-patching": true,
-    "patches": {
-      "drupal/[module_name]": {
-        "Note regarding the nature of the patch being applied": "https://www.drupal.org/files/issues/[patch_name].patch"
-      }
-    },
+    "patches": [],
     "drupal-scaffold": {
       "locations": {
         "web-root": "./[drupal-root]"


### PR DESCRIPTION
RADX-538 - As per investigation some of non-composer docroots failed due to below issue.

<img width="1510" alt="Screenshot 2022-06-01 at 1 58 24 PM" src="https://user-images.githubusercontent.com/75003339/171361787-1025db0a-5e61-413e-b297-a60ae9552dd4.png">

Root Cause- template.composer.json file has example schema mention of patches. that impact of composerize process.

Solution- In place of example schema only blank array is needed.
